### PR TITLE
Feat: add support for base58 hash encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubbit/enigma",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2034,6 +2034,14 @@
             "kind-of": "^6.0.2"
           }
         }
+      }
+    },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "base64-js": {
@@ -7444,8 +7452,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubbit/enigma",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "description": "A fast, native, cryptographic engine for the web",
   "main": "index.js",
@@ -43,6 +43,7 @@
   "homepage": "https://github.com/cubbit/enigma#readme",
   "dependencies": {
     "@cubbit/web-file-stream": "^1.0.0",
+    "base-x": "^3.0.8",
     "bindings": "^1.4.0",
     "fs-extra": "^9.0.1",
     "js-x25519": "git+https://github.com/CryptoEsel/js-x25519.git",

--- a/src/common/utils/base_x.ts
+++ b/src/common/utils/base_x.ts
@@ -1,0 +1,30 @@
+import * as BaseX from 'base-x';
+
+export namespace base_x
+{
+    export type BaseXEncoder = (value: Buffer) => string;
+    export type BaseXDecoder = (value: string) => Buffer;
+
+    const ENCODINGS = {
+        base58: '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
+    };
+
+    export enum Encoding
+    {
+        BASE58 = 'base58',
+    }
+
+    export function make_encoder(to: Encoding): BaseXEncoder
+    {
+        const encoder = BaseX(ENCODINGS[to]);
+
+        return (value: Buffer): string => encoder.encode(value);
+    }
+
+    export function make_decoder(from: Encoding): BaseXDecoder
+    {
+        const decoder = BaseX(ENCODINGS[from]);
+
+        return (value: string): Buffer => decoder.decode(value);
+    }
+}

--- a/tests/unit/common/utils/base_x.spec.ts
+++ b/tests/unit/common/utils/base_x.spec.ts
@@ -1,0 +1,107 @@
+import {base_x} from '../../../../src/common/utils/base_x';
+import * as BaseX from 'base-x';
+
+const converter_mock = {
+    encode: jest.fn(),
+    decode: jest.fn(),
+};
+
+jest.mock('base-x', () => jest.fn().mockImplementation(() => converter_mock));
+
+const ENCODINGS = {
+    base58: '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
+};
+
+describe('base_x', () =>
+{
+    const chosen_encoding = base_x.Encoding.BASE58;
+
+    beforeEach(() =>
+    {
+        jest.clearAllMocks();
+        expect.hasAssertions();
+    });
+
+    describe('make_encoder', () =>
+    {
+        let encoder: base_x.BaseXEncoder;
+
+        beforeEach(() =>
+        {
+            jest.clearAllMocks();
+            expect.hasAssertions();
+
+            encoder = base_x.make_encoder(chosen_encoding);
+        });
+
+        it('should create an BaseX object with the given encoding', () =>
+        {
+            expect(BaseX).toHaveBeenCalledWith(ENCODINGS[chosen_encoding]);
+        });
+
+        it('should call the encode method of base-x', () =>
+        {
+            const value_to_encode = Buffer.from('42', 'base64');
+
+            const encode_spy = jest.spyOn(converter_mock, 'encode');
+
+            encoder(value_to_encode);
+
+            expect(encode_spy).toHaveBeenCalledWith(value_to_encode);
+        });
+
+        it('should return the encoded value', () =>
+        {
+            const value_to_encode = Buffer.from('42', 'base64');
+            const encoded_result = 'encoded_42';
+
+            jest.spyOn(converter_mock, 'encode').mockReturnValue(encoded_result);
+
+            const result = encoder(value_to_encode);
+
+            expect(result).toEqual(encoded_result);
+        });
+    });
+
+    describe('make_decoder', () =>
+    {
+        let decoder: base_x.BaseXDecoder;
+
+        beforeEach(() =>
+        {
+            jest.clearAllMocks();
+            expect.hasAssertions();
+
+            decoder = base_x.make_decoder(chosen_encoding);
+        });
+
+        it('should create an BaseX object with the given encoding', () =>
+        {
+            expect(BaseX).toHaveBeenCalledWith(ENCODINGS[chosen_encoding]);
+        });
+
+        it('should call the decode method of base-x', () =>
+        {
+            const value_to_decode = 'awelfkhasdf';
+            const decoded_value = Buffer.from('42');
+
+            const decode_spy = jest.spyOn(converter_mock, 'decode').mockReturnValue(decoded_value);
+
+            decoder(value_to_decode);
+
+            expect(decode_spy).toHaveBeenCalledWith(value_to_decode);
+        });
+
+        it('should return the decoded value', () =>
+        {
+            const value_to_decode = 'awelfkhasdf';
+            const decoded_value = Buffer.from('42');
+
+            jest.spyOn(converter_mock, 'decode').mockReturnValue(decoded_value);
+
+            const decoded = decoder(value_to_decode);
+
+            expect(decoded).toEqual(decoded_value);
+        });
+    });
+});


### PR DESCRIPTION
## Description
This PR will add support to directly encode the hash in base58:

```typescript
const hash = await Enigma.Hash.digest('secret', {encoding: Enigma.Hash.Encoding.BASE58});
```