### PR TITLE
Fix OpenSSL build and linking warnings on macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -44,7 +44,12 @@
         'conditions': [
             ['OS=="mac"', {
                 'include_dirs': ['<(module_root)/dependencies/openssl/include'],
-                'libraries': ['-Wl,<(module_root)/dependencies/openssl/libcrypto.a']
+                'libraries': ['-Wl,<(module_root)/dependencies/openssl/libcrypto.a'],
+                'defines': [
+                    'CFLAGS=<!(node -p \"require(\'process\').env.MACOS_DEPLOYMENT_TARGET\") ',
+                    'CPPFLAGS=<!(node -p \"require(\'process\').env.MACOS_DEPLOYMENT_TARGET\") ',
+                    'LDFLAGS=<!(node -p \"require(\'process\').env.MACOS_DEPLOYMENT_TARGET\") '
+                ]
             }],
             ['OS=="linux"', {
                 'include_dirs': ['<(module_root)/dependencies/openssl/include'],

--- a/scripts/node/dependencies.js
+++ b/scripts/node/dependencies.js
@@ -8,6 +8,7 @@ const path = require('path');
 const module_path = path.resolve(__dirname, '../..');
 
 const openssl_version = '1.0.2q';
+const macos_deployment_version = '11';
 
 (function dependencies()
 {
@@ -73,6 +74,8 @@ const openssl_version = '1.0.2q';
         else if(platform === 'darwin')
         {
             command = path.resolve(scripts_shell_path, 'prepare.sh');
+
+            env.MACOS_DEPLOYMENT_VERSION = '-mmacosx-version-min=' + macos_deployment_version;
 
             switch(arch)
             {

--- a/scripts/node/shell/prepare.sh
+++ b/scripts/node/shell/prepare.sh
@@ -8,6 +8,6 @@ mkdir openssl
 curl -s https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz | tar -C openssl --strip-components=1 -xzf -
 
 cd openssl
-./Configure $OPENSSL_COMPILER shared no-asm no-bf no-camellia no-cast no-cms no-des no-dh no-ec no-ecdh no-ecdsa no-err no-hw no-idea no-jpake no-krb5 no-md2 no-md4 no-mdc2 no-rc2 no-rc4 no-rc5 no-ripemd no-seed no-ssl2 no-ssl3
+./Configure $OPENSSL_COMPILER shared no-asm no-bf no-camellia no-cast no-cms no-des no-dh no-ec no-ecdh no-ecdsa no-err no-idea no-md2 no-md4 no-mdc2 no-rc2 no-rc4 no-rc5 no-seed no-ssl3 $MACOS_DEPLOYMENT_VERSION
 make depend
 make build_crypto


### PR DESCRIPTION
Add compiler and linker flags to build and link OpenSSL against the same version of the OSX SDK.

This change fixes some warnings.