### PR TITLE
Fix/arm64-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubbit/enigma",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "A fast, native, cryptographic engine for the web",
   "main": "index.js",

--- a/scripts/node/cross.js
+++ b/scripts/node/cross.js
@@ -20,10 +20,10 @@ async function cross()
         switch(arch)
         {
             case "arm64":
-                container = 'dockcross/linux-arm64'
+                container = 'dockcross/linux-arm64-lts'
                 break;
             case "arm":
-                container = 'dockcross/linux-armv7'
+                container = 'dockcross/linux-armv7-lts'
                 break;
 
             default:


### PR DESCRIPTION
Fix arm64 build by using LTS version of dockcross image for building bindings.
