### PR TITLE
Change environment variable to force build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         node: [12, 14]
     env:
       ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  ENIGMA_FORCE_BUILD: "True"
+
 jobs:
   test_and_publish:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - "**"
       - "!master"
 
+env:
+  ENIGMA_FORCE_BUILD: "True"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-latest]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         node: [12, 14]
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubbit/enigma",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "A fast, native, cryptographic engine for the web",
   "main": "index.js",

--- a/scripts/node/install.js
+++ b/scripts/node/install.js
@@ -28,7 +28,7 @@ function install()
 {
     return new Promise((resolve, reject) =>
     {
-        if(process.env.CI)
+        if(process.env.ENIGMA_FORCE_BUILD)
         {
             if(_build())
                 return resolve();


### PR DESCRIPTION
Using the `CI` environment variable as force build in the post-install script means that it is rebuilt in every CI environment of dependents packages.

Switch to a new variable (`ENIGMA_FORCE_BUILD`) that is set in the enigma CI